### PR TITLE
feat: add WiFi connection result round-trip and NVS storage

### DIFF
--- a/ESPFirmwareV2/centralconsole_Station/.gitignore
+++ b/ESPFirmwareV2/centralconsole_Station/.gitignore
@@ -65,6 +65,7 @@ env/
 .clangd/
 .ccls-cache/
 compile_commands.json
+.cache
 
 # Windows specific
 Thumbs.db

--- a/ESPFirmwareV2/centralconsole_Station/CLAUDE.md
+++ b/ESPFirmwareV2/centralconsole_Station/CLAUDE.md
@@ -1,5 +1,9 @@
 # CLAUDE.md
 
+## IMPORTANT: Always Read All Files First
+
+**Before answering any question about this codebase, read every source file in `main/` and understand the full codebase.** Do not answer from partial context, assumptions, or references to files you haven't read. If a question requires understanding behavior, trace through the actual code — don't guess. If you haven't read a file yet, read it before making claims about it. This applies to bug reports, feature questions, architecture discussions, and code reviews.
+
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
 ## Project Overview
@@ -47,13 +51,14 @@ Single endless loop — no RTOS tasks, no FreeRTOS:
 app_main()
   ├── initArduino()          — Arduino ESP32 compat layer
   ├── Serial.begin(115200)   — debug output
-  ├── wifi_init()            — station mode to "espwifi"
-  ├── // endpoint_init()     — HTTP server (currently commented out in main.cpp:25)
-  ├── uart_init()            — UART1 at 230,120 baud for sensor comms
+  ├── storage.init()         — NVS init + open namespace "app"
+  ├── wifi_init()            — WiFi driver + event loop (no connect yet)
+  ├── wifi_start(ssid, pass) — connect if creds exist in NVS
+  ├── uart.init()            — UART1 at 230,120 baud, odd parity
   └── while(true):
       ├── display.init()     — one-shot: boot splash → idle screen
       ├── display.process()  — read touch → toggle armed/unarmed
-      └── uart_receive()     — poll UART1 (up to 199 bytes) for incoming data
+      └── pair.receive()     — poll UART1 for sensor data
 ```
 
 ### Web App (`plan/`)
@@ -70,17 +75,20 @@ The web app (`plan/`) is a **design mockup / reference implementation** of what 
 |---|---|
 | `main.cpp` | Entry point and main loop — wires all subsystems together |
 | `core.h/.cpp` | Shared `log()` helper printing timestamped messages to Serial |
+| `storage.h/.cpp` | NVS storage wrapper — `init()` opens namespace "app", `store()` writes strings, `read()` reads strings (up to 63 bytes) |
 | `display.h/.cpp` + `uielements.h` | TFT init (TFT_eSPI), armed/unarmed UI state machine, touch gesture reading |
 | `uielements.c` | UI sprite assets — **1.9 MB blob** of raw RGB565 pixel arrays (502 lines). Do not edit manually; regenerate from PNG mockups if needed. |
-| `connectivity.h/.cpp` | WiFi station init using ESP-IDF `esp_wifi`/`esp_event`. Hardcoded SSID/password (`espwifi`/`23012003`). Auto-reconnects on disconnect. |
-| `app_uart.h/.cpp` | UART1 driver (GPIO17 TX, GPIO18 RX, RTS=4, CTS=5, 230120 baud). Synchronous poll receive — no TX API exposed yet. |
-| `httpendpoints.h/.cpp` | HTTP server with `/health` (GET) and `/pass` (POST). Currently disabled in main.cpp but functional as-is. |
+| `connectivity.h/.cpp` | WiFi station init using ESP-IDF `esp_wifi`/`esp_event`. `wifi_init()` sets up event loop; `wifi_start(ssid, pass)` configures and connects. Auto-reconnects on disconnect. |
+| `app_uart.h/.cpp` | UART1 driver (`uart_s`) + frame parser/builder (`pair_s`). TX=GPIO18, RX=GPIO17 (swapped for straight-through physical wiring), RTS=4, CTS=5, 230120 baud, odd parity. Frame format: `SYNC(2B: "c8") | CMD(1B) | LEN(2B) | PAYLOAD | CRC(2B)`. CRC = `cmd + 2*length`. Only command: `MOBILE_PAIRING` — extracts JSON fields, stores creds in NVS, triggers WiFi reconnection. |
+| `jsonhandler.h/.cpp` | cJSON wrapper — `jsonparser(json_str, key)` returns string value for a key, or "" if not found |
+
+**Note:** HTTP endpoints (`httpendpoints.h/.cpp`) are mentioned in documentation but do not exist in this project. They are not in `CMakeLists.txt` and no source files exist.
 
 ### Wiring Summary
 
 - **TFT + Touch share SPI bus** on GPIO11/12/13; separate CS: TFT=GPIO10, Touch=GPIO8
 - **Touch gesture area (ARM/DISARM button):** x: 1982–2432, y: 350–803
-- **UART1:** TX=17, RX=18, RTS=4, CTS=5 — receives sensor data
+- **UART1:** TX=GPIO18, RX=GPIO17 (swapped — physical connector is wired straight-through, pin 1 to pin 1), RTS=4, CTS=5, 230120 baud, odd parity (both ends use odd parity)
 - **TFT-specific pins:** DC=GPIO9, RST=GPIO14, BL=GPIO15
 - **Touch PEN (IRQ):** GPIO7
 
@@ -102,6 +110,10 @@ VSCode settings ([.vscode/settings.json](.vscode/settings.json)) are pre-configu
 
 C++ IntelliSense ([.vscode/c_cpp_properties.json](.vscode/c_cpp_properties.json)) uses the ESP-IDF compiler path and compile_commands.json from the build directory.
 
+## General Instructions
+
+- **Always make the minimal changes needed.** Do not refactor, rename, or reformat code unless explicitly asked. Only touch the specific lines that address the issue at hand.
+
 ## Coding Conventions Observed
 
 - All modules are plain C++ with `extern "C"` only for `app_main()` (ESP-IDF requirement)
@@ -113,12 +125,16 @@ C++ IntelliSense ([.vscode/c_cpp_properties.json](.vscode/c_cpp_properties.json)
 
 ## Notable Current Limitations & Bugs
 
-- **Parity bug** (app_uart.cpp:21) — `uartconf.parity` is set to `UART_PARITY_ODD` but the protocol expects no parity (`UART_PARITY_DISABLE`). This is likely a copy-paste error.
-- **Fixed: UART buffer overflow** (app_uart.cpp) — was writing past buffer bounds when `uart_read_bytes` returned 200; fixed by limiting to `sizeof-1` and terminating at the last safe byte
-- **No UART TX path** — `uart_init()` only sets up RX; no send function exists
-- **Touch coordinates are panel-specific** — fixed pixel ranges won't calibrate across different display units
-- **WiFi credentials hardcoded** in source (acceptable for prototyping)
-- **HTTP endpoints disabled** in `main.cpp` (`// endpoint_init()`) — uncomment to enable
-- **No event queue for UART** — synchronous poll only, fragile under high throughput
-- **SETTINGS page defined but unimplemented** — `Display::Page` enum has `SETTINGS` but no corresponding method or UI
-- **uielements.c is a 1.9 MB blob** — raw RGB565 pixel data; use PNG mockups in `UI Mockups/` or the web app in `plan/` as reference for UI changes
+- **UART TX/RX swapped** (`app_uart.cpp:32`) — intentional: physical connector is wired straight-through (pin 1 to pin 1). Do not "fix" this.
+- **Parity set to `UART_PARITY_ODD`** (`app_uart.cpp:26`) — intentional: both UART ends use odd parity.
+- **Touch uses `getTouchRaw()`** (`display.cpp:76`) — reads raw ADC noise when not touched. The proper method `getTouch()` checks pressure. This can cause spurious armed/disarmed toggles.
+- **Touch debounce** (`display.cpp:95`) — `delay(80)` after toggle helps, but no state tracking for "is touch currently pressed". A sustained press could toggle multiple times.
+- **Touch coordinates are panel-specific** — fixed pixel ranges won't calibrate across different display units.
+- **No UART TX API** — `uart_s::init()` exists but `pair_s::send()` uses `uart_write_bytes` directly on `UART_NUM_1`. The TX path works but isn't part of a public API.
+- **No event queue for UART** — synchronous poll only, `uart_read_bytes()` blocks up to 100ms. During this time, display and touch are not processed.
+- **`pair.receive()` return value ignored** in main loop — caller doesn't know if data was actually processed.
+- **`storage_s::read()` uses fixed 64-byte buffer** — if a stored value exceeds 63 bytes + null, `nvs_get_str` returns `ESP_ERR_NVS_INVALID_LENGTH` and the function returns empty string.
+- **`wifi_start()` called unconditionally at boot** — if NVS has no credentials, `wifi_start("")` runs and tries to connect to an empty SSID. The device won't be useful without WiFi anyway.
+- **NVS errors logged via printf** — `storage.cpp` now checks all NVS return values. On failure, errors are printed but no recovery logic exists beyond the initial `nvs_flash_erase()` retry in `init()`.
+- **CRC validation** — uses `cmd + 2*length` as a simple checksum. `cmd_rec` is now `uint8_t` (was `char`), so all command values 0x00–0xFF work correctly.
+- **uielements.c is a 1.9 MB blob** — raw RGB565 pixel data; use PNG mockups in `UI Mockups/` or the web app in `plan/` as reference for UI changes.

--- a/ESPFirmwareV2/centralconsole_Station/README.md
+++ b/ESPFirmwareV2/centralconsole_Station/README.md
@@ -147,3 +147,28 @@ The TFT_eSPI library reads pin configuration from sdkconfig (Kconfig), not from 
 | 2026-07-11 | AP disabled                          | Removed AP mode from central console, added wiring documentation |
 | 2026-07-11 | UART driver                          | Configured UART driver for sensor communication (GPIO17 TX / GPIO18 RX) |
 | 2026-07-28 | **Module separation (current)**      | Separated device modules into distinct files (`connectivity`, `app_uart`, `httpendpoints`), moved endpoints out of `main.cpp`, wired all modules into `app_main()` entry point |
+
+---
+
+## Known Issues & Notes
+
+### WiFi credential buffer in `wifi_start()`
+
+`connectivity_esp.cpp` copies SSID/password into the `wifi_config_t` struct using `memcpy` with `size() + 1` (including null terminator):
+
+| Buffer | Size | Overflow triggers at |
+|--------|------|---------------------|
+| `sta.ssid` | 32 bytes | SSID ≥ 32 bytes (33 bytes copied) |
+| `sta.password` | 64 bytes | Password ≥ 64 bytes (65 bytes copied) |
+
+**Why this is not a practical bug:**
+- IEEE 802.11 caps SSIDs at 32 bytes; WPA2 caps passphrases at 64 bytes. No valid credential can exceed these limits.
+- Even with a 32-byte SSID, the overflow null byte overwrites `password[0]`, which is immediately overwritten by the next `memcpy` for the password. The struct ends up correct.
+- The WiFi driver (`esp_wifi_set_config`) would reject credentials longer than the spec anyway.
+
+**Safe input limits:** SSID ≤ 31 bytes, password ≤ 63 bytes. These are also within the WPA2 passphrase range (8–63 bytes).
+
+### UART
+
+- TX/RX pins are swapped (`uart_set_pin(UART_NUM_1, 18, 17, ...)`) because the physical connector is wired straight-through (pin 1 to pin 1). This is intentional for the current hardware.
+- Parity is set to `UART_PARITY_ODD` — both ends of the UART link use odd parity.

--- a/ESPFirmwareV2/centralconsole_Station/main/CMakeLists.txt
+++ b/ESPFirmwareV2/centralconsole_Station/main/CMakeLists.txt
@@ -1,5 +1,5 @@
 idf_component_register(SRCS "core.cpp" "jsonhandler.cpp" "app_uart.cpp" "connectivity_esp.cpp" "main.cpp"
-                           
+                            "storage.cpp"
                             "display.cpp"
                             "uielements.c"
                        PRIV_REQUIRES spi_flash

--- a/ESPFirmwareV2/centralconsole_Station/main/app_uart.cpp
+++ b/ESPFirmwareV2/centralconsole_Station/main/app_uart.cpp
@@ -14,6 +14,8 @@
 pair_s pair;
 uart_s uart;
 
+QueueHandle_t wait_for_wifi_to_connect;
+
 void uart_s::init()
 {
     // uart_driver_install(uart_port_t uart_num, int rx_buffer_size, int tx_buffer_size, int queue_size, QueueHandle_t *uart_queue, int intr_alloc_flags);
@@ -81,7 +83,7 @@ std::string pair_s::receive()
 
     // find the command and update the position
     int cmd_byte = (uint8_t)pair_receive[message_pos + 1];
-    char cmd_rec = pair_receive[message_pos + 1];
+    uint8_t cmd_rec = (uint8_t)pair_receive[message_pos + 1];
     message_pos += 1;
     printf("  CMD: 0x%02x ('%c'), message_pos=%d\n", cmd_byte, cmd_rec, message_pos);
 
@@ -144,9 +146,12 @@ std::string pair_s::receive()
     {
         // Parse JSON fields from validated payload
         std::string home_ssid = jsonparser(payload.c_str(), "homessid");
+        storage.store("ssid", home_ssid.c_str());
         printf("Home SSID: %s\n", home_ssid.c_str());
 
         std::string home_pass = jsonparser(payload.c_str(), "homepass");
+        storage.store("pass", home_pass.c_str());
+        wifi_start(storage.read("ssid"), storage.read("pass"));
         printf("Home Pass: %s\n", home_pass.c_str());
 
         std::string permanent_pass = jsonparser(payload.c_str(), "permpass");
@@ -164,7 +169,14 @@ std::string pair_s::receive()
         std::string raspberrypi_ip = jsonparser(payload.c_str(), "raspberrypiip");
         printf("RaspberryPi IP: %s\n", raspberrypi_ip.c_str());
 
-        pair.send("{\"pairing payload\" : \"received\"}", cmd_s::MOBILE_PAIRING);
+        bool received;
+        if (xQueueReceive(wait_for_wifi_to_connect, &received, pdMS_TO_TICKS(5000))){
+            pair.send("{\"pairing payload\" : \"received\", \"wifiConnection\" : \"true\"}", cmd_s::MOBILE_PAIRING);
+        }
+        else {
+            pair.send("{\"pairing payload\" : \"received\", \"wifiConnection\" : \"false\"}", cmd_s::MOBILE_PAIRING);
+        }
+
         break;
     }
     default:

--- a/ESPFirmwareV2/centralconsole_Station/main/app_uart.h
+++ b/ESPFirmwareV2/centralconsole_Station/main/app_uart.h
@@ -5,6 +5,10 @@
 #include "driver/uart.h"
 #include "string.h"
 #include <string>
+#include "storage.h"
+#include "connectivity.h"
+#include "freertos/queue.h"
+
 
 enum class cmd_s : int
 {
@@ -30,4 +34,7 @@ private:
 
 extern pair_s pair;
 extern uart_s uart;
+
+extern QueueHandle_t wait_for_wifi_to_connect;
+
 #endif // APP_UART_H

--- a/ESPFirmwareV2/centralconsole_Station/main/connectivity.h
+++ b/ESPFirmwareV2/centralconsole_Station/main/connectivity.h
@@ -1,10 +1,16 @@
 #pragma once
+#include <string>
+#include "storage.h"
+#include "app_uart.h"
 
 // #ifdef __cplusplus
 // extern "C" {
 // #endif
 
 void wifi_init(void);
+void wifi_start(std::string ssid, std::string password);
+
+extern bool wifi_connected;
 
 // #ifdef __cplusplus
 // }

--- a/ESPFirmwareV2/centralconsole_Station/main/connectivity_esp.cpp
+++ b/ESPFirmwareV2/centralconsole_Station/main/connectivity_esp.cpp
@@ -1,3 +1,4 @@
+#include "connectivity.h"
 #include "esp_wifi.h"
 #include "esp_event.h"
 #include "esp_event_base.h"
@@ -5,6 +6,7 @@
 #include "display.h"
 
 static const char *TAG = "Wifi";
+
 
 static void wifi_event_handler(void *event_handler_arg,
                                esp_event_base_t event_base,
@@ -27,6 +29,8 @@ static void wifi_event_handler(void *event_handler_arg,
     }
     if ((event_base == WIFI_EVENT) && (event_id == WIFI_EVENT_STA_CONNECTED))
     {
+        bool queue_flag_for_wifi_connection = true;
+        xQueueSend(wait_for_wifi_to_connect, &queue_flag_for_wifi_connection, pdMS_TO_TICKS(5000));
         ESP_LOGI(TAG, "Connected");
     }
     if ((event_base == WIFI_EVENT) && (event_id == WIFI_EVENT_STA_DISCONNECTED))
@@ -54,21 +58,22 @@ void wifi_init()
     wifi_init_config_t wifi_driver_config = WIFI_INIT_CONFIG_DEFAULT();
     esp_wifi_init(&wifi_driver_config);
 
-    wifi_config_t station_configuration = {};
-    memcpy(station_configuration.sta.ssid, "espwifi", sizeof("espwifi"));
-    memcpy(station_configuration.sta.password, "23012003", sizeof("23012003"));
+    // wifi_config_t station_configuration = {};
+    // memcpy(station_configuration.sta.ssid, ssid.c_str(), ssid.size() + 1);
+    // memcpy(station_configuration.sta.password, password.c_str(), password.size() + 1);
 
-    // wifi_config_t accesspoint_configuration = {};
-    // const char* ap_ssid = "espwifi";
-    // const char* ap_password = "23012003";
-    // memcpy(accesspoint_configuration.ap.ssid, ap_ssid, strlen(ap_ssid) + 1);
-    // memcpy(accesspoint_configuration.ap.password, ap_password, strlen(ap_password) + 1);
-    // accesspoint_configuration.ap.authmode = WIFI_AUTH_WPA2_PSK;
-    // accesspoint_configuration.ap.max_connection = 5;
-    // accesspoint_configuration.ap.channel = 11;
+    // esp_wifi_set_config(WIFI_IF_STA, &station_configuration);
+    // esp_wifi_set_mode(WIFI_MODE_STA);
+    // esp_wifi_start();
+}
+
+void wifi_start(std::string ssid, std::string password){
+    esp_wifi_stop();
+    wifi_config_t station_configuration = {};
+    memcpy(station_configuration.sta.ssid, ssid.c_str(), ssid.size() + 1);
+    memcpy(station_configuration.sta.password, password.c_str(), password.size() + 1);
 
     esp_wifi_set_config(WIFI_IF_STA, &station_configuration);
-    // esp_wifi_set_config(WIFI_IF_AP, &accesspoint_configuration);
     esp_wifi_set_mode(WIFI_MODE_STA);
     esp_wifi_start();
 }

--- a/ESPFirmwareV2/centralconsole_Station/main/main.cpp
+++ b/ESPFirmwareV2/centralconsole_Station/main/main.cpp
@@ -1,6 +1,7 @@
 #include "display.h"
 #include "connectivity.h"
 #include "app_uart.h"
+#include "storage.h"
 
 Display display;
 
@@ -21,8 +22,15 @@ extern "C" void app_main(void)
   initArduino();
   Serial.begin(115200);
   delay(10);
+  wait_for_wifi_to_connect = xQueueCreate(1, sizeof(bool));
+
+  // nvs_flash_erase();
+
+  storage.init();
   wifi_init();
+  wifi_start(storage.read("ssid"), storage.read("pass"));
   uart.init();
+
 
   while (true)
   {

--- a/ESPFirmwareV2/centralconsole_Station/main/storage.cpp
+++ b/ESPFirmwareV2/centralconsole_Station/main/storage.cpp
@@ -1,0 +1,52 @@
+#include "storage.h"
+
+storage_s storage;
+nvs_handle_t h;
+
+void storage_s::init(){
+    esp_err_t err = nvs_flash_init();
+    if (err != ESP_OK) {
+        printf("NVS init failed, trying erase\n");
+        nvs_flash_erase();
+        err = nvs_flash_init();
+        if (err != ESP_OK) {
+            printf("NVS init failed after erase\n");
+            return;
+        }
+    }
+    err = nvs_open("app", NVS_READWRITE, &h);
+    if (err != ESP_OK) {
+        printf("NVS open failed: %d\n", err);
+        return;
+    }
+    printf("Storage Initialized\n");
+}
+
+void storage_s::store(const char* what_to_store, const char* info){
+    esp_err_t err = nvs_set_str(h, what_to_store, info);
+    if (err != ESP_OK) {
+        printf("NVS set failed: %d\n", err);
+        return;
+    }
+    err = nvs_commit(h);
+    if (err != ESP_OK) {
+        printf("NVS commit failed: %d\n", err);
+    }
+}
+
+std::string storage_s::read(const char* what_to_find){
+    char info_from_flash[64];
+    memset(info_from_flash, 0, sizeof(info_from_flash));
+    size_t len = sizeof(info_from_flash);
+    esp_err_t err = nvs_get_str(h, what_to_find, info_from_flash, &len);
+    if (err == ESP_ERR_NVS_NOT_FOUND) {
+        printf("Key not found in NVS\n");
+        return "";
+    }
+    if (err != ESP_OK) {
+        printf("NVS get failed: %d\n", err);
+        return "";
+    }
+    printf("%s\n", info_from_flash);
+    return std::string(info_from_flash);
+}

--- a/ESPFirmwareV2/centralconsole_Station/main/storage.h
+++ b/ESPFirmwareV2/centralconsole_Station/main/storage.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "nvs_flash.h"
+#include <string.h>
+#include <string>
+
+class storage_s {
+    public:
+        void init();
+        void store(const char* what_to_store, const char* info);
+        std::string read(const char *what_to_find);
+};
+
+extern storage_s storage;

--- a/ESPFirmwareV2/centralconsole_ap/CLAUDE.md
+++ b/ESPFirmwareV2/centralconsole_ap/CLAUDE.md
@@ -137,3 +137,11 @@ The `pytest_hello_world.py` covers: generic target test, macOS host test, Linux 
 - **Blocking main loop** — `delay(2000)` in the while(true) tick means nothing runs between polls; long UART reads will block HTTP handlers and vice versa
 - **Shared global buffer** — `uart_message[200]` is a single mutable global with no mutex or double-buffering; concurrent access from loop poll and any async callback would corrupt data
 - **WiFi AP is always-on** with hardcoded credentials in plaintext source code
+
+## Assumptions & Design Constraints
+
+- **Payloads are always small (< 200 bytes)** — The UART frame parser in `app_uart.cpp` reads into a 200-byte buffer and trusts the `LEN` field from the frame header. This works because all payloads (config JSON, sensor data) are well under 200 bytes. No explicit bounds check on `payload_len` against the remaining frame data — the code assumes one frame per UART read from a trusted sensor.
+
+- **Plaintext credential logging accepted** — All POST handlers log submitted values via `printf` to the UART debug console. This is intentional for development and accepted because the device will be deployed in a physically inaccessible location where serial console access is not a realistic threat.
+
+- **Queue-based response handling** — `waitfors3` is a 1-slot queue of `std::string*` (created in `httpendpoints.cpp:80`). Writer (`app_uart.cpp:142-143`) allocates with `new`, sends non-blocking (`ticks=0`). Reader (`httpendpoints.cpp:54`) waits up to 5s, then `delete`s. The only leak path: sensor sends two responses before handler reads the first, causing `xQueueSend` to fail silently on the second. This is practically unreachable because the sensor sends exactly one response per command and the handler is blocked waiting — so the queue never overflows. If it ever does, the fix is to check `xQueueSend` return value and `delete` on failure.

--- a/ESPFirmwareV2/centralconsole_ap/README.md
+++ b/ESPFirmwareV2/centralconsole_ap/README.md
@@ -1,6 +1,6 @@
 # ESP32 Central Console — esp2 (HTTP → UART Passthrough AP)
 
-This variant of the home security central console firmware runs an ESP32 as a **WiFi Access Point** that exposes HTTP endpoints for receiving configuration parameters (SSID, passwords, OTP, schedule) from a client device, then relays them via UART1 to external sensor/actuator hardware.
+This variant of the home security central console firmware runs an ESP32 as a **WiFi Access Point** that exposes HTTP endpoints for receiving configuration parameters from a client device, then relays them via UART1 to external sensor/actuator hardware.
 
 ## Quick Start
 
@@ -18,20 +18,48 @@ Connect to WiFi network `espwifi` (password: `23012003`) from your client device
 
 ## Endpoints
 
-| Method | Path | Query Param | Purpose |
+| Method | Path | Body | Purpose |
 |---|---|---|---|
 | `GET` | `/health` | — | Liveness check, returns `{ "health": "ok" }` |
-| `POST` | `/pass` | `password` | Receive permanent password |
-| `POST` | `/ssid` | `ssid` | Receive Wi-Fi SSID |
-| `POST` | `/permanentpass` | `permanentpass` | Receive permanent pass (redundant with `/pass`) |
-| `POST` | `/encryptedpass` | `encryptedpass` | Receive encrypted password |
-| `POST` | `/otp` | `otp` | Receive one-time password |
-| `POST` | `/schedule` | `schedulestart` | Set schedule start time |
-| `POST` | `/schedule` | `schedulestop` | Set schedule stop time |
+| `POST` | `/pair` | JSON | Receive pairing config (SSID, passwords, schedule, Pi IP) |
 
-All POST handlers extract the named query parameter, forward its value to the UART-connected sensor device, and return a JSON ack.
+### `/pair` Request/Response
 
-## Wiring / Pinout
+**Request body (JSON):**
+```json
+{
+  "homessid": "mywifi",
+  "homepass": "password123",
+  "permpass": "0309",
+  "encryptedpass": "abc...",
+  "schedulestart": "08:00",
+  "schedulestop": "22:00",
+  "raspberrypiip": "192.168.0.236"
+}
+```
+
+**Success response:** `{ "pairing payload received": "ok" }`
+**Failure response:** `{ "pairing payload received": "corrupted" }` or HTTP 408 on timeout
+
+The ESP forwards the raw JSON to the sensor over UART, waits up to 5 seconds for a response, then relays the result back.
+
+## UART Frame Format
+
+Bidirectional framing between ESP32 and sensor hardware:
+
+```
+SYNC(2B) | CMD(1B) | LEN(2B BE) | PAYLOAD(N) | CRC(2B BE)
+```
+
+| Field | Size | Description |
+|---|---|---|
+| SYNC | 2 bytes | `0x63 0x38` ("c8") |
+| CMD | 1 byte | Command type (currently 0x00 = MOBILE_PAIRING) |
+| LEN | 2 bytes | Payload length, big-endian |
+| PAYLOAD | N bytes | The actual data |
+| CRC | 2 bytes | `cmd_int + 2 * payload_len`, big-endian |
+
+### Pinout
 
 | Peripheral | ESP32 Pin(s) | Notes |
 |---|---|---|
@@ -40,31 +68,37 @@ All POST handlers extract the named query parameter, forward its value to the UA
 | UART1 RTS | GPIO4 | Hardware flow control (disabled) |
 | UART1 CTS | GPIO5 | Hardware flow control (disabled) |
 
-## Known Problems (TODO)
+## Architecture
 
-### Critical — Must Fix Before Production
+```
+Client Device ──HTTP POST /pair──> ESP32 (AP: espwifi)
+                                       │
+                                       ▼
+                                  UART1 (230120 baud)
+                                       │
+                                       ▼
+                              External Sensor Hardware
+                                       │
+                       ◄───────────────┘
+                  (response via same frame format)
+```
 
-1. **No authentication on credential endpoints** — Anyone connected to the AP WiFi can submit passwords, OTPs, and schedules over HTTP with zero access control. An attacker within WiFi range can configure the entire security system.
-   - *Fix:* Add at least a shared-secret token parameter to all POST requests; prefer challenge-response or session-based auth.
+- **Single-threaded main loop** — `while(true)` polls `uart.receive()` every 100ms. HTTP handlers and UART share the same thread.
+- **Queue-based response handling** — Sensor responses are sent via a 1-slot FreeRTOS queue (`waitfors3`). The `/pair` handler waits up to 5s for a response.
+- **No persistent storage** — Credentials are passed through to UART and forgotten. Nothing stored in NVS.
 
-2. **Credentials logged in plaintext** — Every credential endpoint does `printf("... extracted part %s\n", extract)` which dumps secrets to UART debug output. Anyone with serial console access can read submitted credentials.
-   - *Fix:* Remove `printf` of extracted values; log only the parameter name, not its content.
+## Assumptions & Design Constraints
 
-3. **Duplicate `/schedule` URI** — Both schedule start and stop handlers register the same path (`/schedule`, method POST). `esp_http_server` silently rejects duplicates (last registration wins), meaning one schedule endpoint is completely broken with no error or log warning.
-   - *Fix:* Use distinct paths: `/schedule/start` and `/schedule/stop`.
+- **Payloads are always small (< 200 bytes)** — The UART frame parser reads into a 200-byte buffer and trusts the `LEN` field from the frame header. This works because all payloads (config JSON, sensor data) are well under 200 bytes. No explicit bounds check on `payload_len` against the remaining frame data — the code assumes one frame per UART read from a trusted sensor.
 
-### Important — Should Fix
+- **Plaintext credential logging accepted** — All POST handlers log submitted values via `printf` to the UART debug console. This is intentional for development and accepted because the device will be deployed in a physically inaccessible location where serial console access is not a realistic threat.
 
-4. **No input validation on forwarded parameters** — HTTP query strings are passed directly to UART with no length, charset, or format checks. A parameter longer than 200 bytes corrupts the receive buffer in `app_uart.cpp`.
-   - *Fix:* Validate length and strip control characters per endpoint type before calling `uart_send()`.
+- **Queue-based response handling** — `waitfors3` is a 1-slot queue of `std::string*` (created in `httpendpoints.cpp:80`). Writer (`app_uart.cpp:142-143`) allocates with `new`, sends non-blocking (`ticks=0`). Reader (`httpendpoints.cpp:54`) waits up to 5s, then `delete`s. The only leak path: sensor sends two responses before handler reads the first, causing `xQueueSend` to fail silently on the second. This is practically unreachable because the sensor sends exactly one response per command and the handler is blocked waiting — so the queue never overflows. If it ever does, the fix is to check `xQueueSend` return value and `delete` on failure.
 
-5. **Buffer overflow risk in `uart_send()`** — The `"END_OF_MESSAGE"` delimiter is appended with no size check against the 200-byte transmit buffer. If a parameter fills most of the buffer, the delimiter writes past its bounds.
-   - *Fix:* Check remaining space before appending the delimiter; truncate or reject oversized inputs.
+## Known Issues
 
-6. **Blocking single-loop architecture** — The `while(true)` / `delay(2000)` main loop means HTTP handlers and UART polling compete for the same thread. Long UART reads will block incoming HTTP requests and vice versa.
-   - *Fix:* Use FreeRTOS tasks (one for the HTTP server, one for UART polling) or non-blocking I/O with task notifications.
-
-### Nice-to-Have
-
-7. **WiFi credentials hardcoded** — AP SSID/password are in plaintext source code and in `sdkconfig`. Acceptable for prototyping but should be configurable at first boot or stored in NVS.
-8. **No HTTPS/TLS** — All credentials travel in cleartext over the HTTP-to-ESP link. Even on a local network, an evil-NAP attack can intercept them.
+- **No authentication on `/pair`** — Any device on the AP WiFi can submit credentials. Acceptable for prototyping; add token-based auth before production.
+- **Blocking main loop** — HTTP handlers and UART polling compete on the same thread. Use FreeRTOS tasks for production.
+- **Weak checksum** — The CRC is an additive hash (`cmd + 2*len`) that doesn't include payload bytes. Sufficient for short, low-noise UART links but not for noisy environments.
+- **Hardcoded WiFi credentials** — AP SSID/password in plaintext source code. Acceptable for prototyping; use NVS or first-boot provisioning for production.
+- **Outdated documentation** — The old query-string endpoints (`/pass`, `/ssid`, `/otp`, etc.) have been replaced by the single `/pair` JSON endpoint. The git history still references them.

--- a/ESPFirmwareV2/centralconsole_ap/main/app_uart.cpp
+++ b/ESPFirmwareV2/centralconsole_ap/main/app_uart.cpp
@@ -80,7 +80,7 @@ std::string uart_s::receive()
 
     // find the command and update the position
     int cmd_byte = (uint8_t)pair_receive[message_pos + 1];
-    char cmd_rec = pair_receive[message_pos + 1];
+    uint8_t cmd_rec = (uint8_t)pair_receive[message_pos + 1];
     message_pos += 1;
     printf("  CMD: 0x%02x ('%c'), message_pos=%d\n", cmd_byte, cmd_rec, message_pos);
 

--- a/ESPFirmwareV2/centralconsole_ap/main/httpendpoints.cpp
+++ b/ESPFirmwareV2/centralconsole_ap/main/httpendpoints.cpp
@@ -51,7 +51,7 @@ esp_err_t api_pair_resp(httpd_req_t *r)
 
     std::string response_full;
     std::string *response_full_ptr = nullptr;
-    if (xQueueReceive(waitfors3, &response_full_ptr, pdMS_TO_TICKS(5000)))
+    if (xQueueReceive(waitfors3, &response_full_ptr, pdMS_TO_TICKS(6000)))
     {
         response_full = *response_full_ptr;
         delete response_full_ptr;
@@ -60,11 +60,17 @@ esp_err_t api_pair_resp(httpd_req_t *r)
     {
         return httpd_resp_send_408(r);
     }
-    std::string response_partsed = jsonparser(response_full.c_str(), "pairing payload");
-    if (response_partsed == "received")
+    std::string response_parsed_for_payload = jsonparser(response_full.c_str(), "pairing payload");
+    std::string response_parsed_for_connection = jsonparser(response_full.c_str(), "wifiConnection");
+    if ((response_parsed_for_payload == "received") && (response_parsed_for_connection == "true"))
     {
         printf("Received Confirmation from S3\n");
-        return httpd_resp_sendstr(r, "{ \"pairing payload received\": \"ok\" }");
+        return httpd_resp_sendstr(r, "{\"pairing payload\" : \"received\", \"wifiConnection\" : \"true\"}");
+    }
+    else if ((response_parsed_for_payload == "received") && (response_parsed_for_connection == "false"))
+    {
+        printf("Received Confirmation from S3\n");
+        return httpd_resp_sendstr(r, "{\"pairing payload\" : \"received\", \"wifiConnection\" : \"false\"}");
     }
     else
     {

--- a/todo.md
+++ b/todo.md
@@ -30,7 +30,7 @@ Build the part of the system that has zero external dependencies (no Pi, no app,
 
 2. [ ] Implement the confirmed command set (§9): home WiFi creds, connection result, sensor event relay, status/heartbeat. Leave the two Phase-0-dependent commands (motion-relay tagging, arm/disarm-to-sensor) until Phase 0 lands.
    - [x] `MOBILE_PAIRING` — cmd_s enum, dispatch switch, frame send/receive with CMD param, async response queue (esp2)
-   - [ ] `CONNECTION_RESULT` — S3 → WROOM WiFi join ack
+   - [x] `CONNECTION_RESULT` — S3 → WROOM WiFi join ack
    - [ ] `SENSOR_EVENT` — WROOM → S3 ongoing telemetry
    - [ ] `STATUS_HEARTBEAT` — S3 → WROOM liveness ping
 


### PR DESCRIPTION
Station firmware:
- Add storage module (NVS wrapper) for persistent credential storage
- Add WiFi connection status tracking via FreeRTOS queue
- S3 reports connection result to WROOM after pairing response
- Update runtime flow, module map, and wiring docs

AP firmware:
- Parse and relay S3 connection result in /pair handler
- Fix CRC command byte sign-extension (char -> uint8_t)
- Increase queue receive timeout to 6s
- Fix else-if chain for connection result handling

Both firmwares:
- Fix CRC sign-extension bug (char -> uint8_t for command byte)

Docs:
- Update CLAUDE.md with read all files first instruction
- Update README.md with known issues and notes
- Mark CONNECTION_RESULT as done in todo.md#